### PR TITLE
Add support for reserved_ip_ranges for redis

### DIFF
--- a/google-redis.yml
+++ b/google-redis.yml
@@ -90,7 +90,12 @@ provision:
     prohibit_update: true 
   - field_name: authorized_network_id
     type: string
-    details: The id of the Google Compute Engine network to which the instance is connected.    
+    details: The id of the Google Compute Engine network to which the instance is connected.
+    default: ""
+    prohibit_update: true
+  - field_name: reserved_ip_range
+    type: string
+    details: The range of ip addresses reserved for this instance.
     default: ""
     prohibit_update: true     
   computed_inputs:

--- a/terraform/provision-redis.tf
+++ b/terraform/provision-redis.tf
@@ -7,12 +7,13 @@ variable region { type = string }
 variable memory_size_gb { type = number }
 variable labels { type = map }
 variable credentials { type = string }
-variable project { type = string }  
+variable project { type = string }
+variable reserved_ip_range { type = string }
 
 provider "google" {
   version = ">=3.17.0"
   credentials = var.credentials
-  project     = var.project      
+  project     = var.project
 }
 
 data "google_compute_network" "authorized-network" {
@@ -32,6 +33,7 @@ resource "google_redis_instance" "instance" {
   region             = var.region
   authorized_network = local.authorized_network_id
   labels             = var.labels
+  reserved_ip_range  = var.reserved_ip_range == "" ? null : var.reserved_ip_range
 
   timeouts {
     create = "15m"


### PR DESCRIPTION
Issue resolved: We had accidentally left out the declaration of the variable when committing.

We do not have a cloudfoundry to hand - wonder if you have an easy way to test this change?