### PR TITLE
feat!: update to use latest Terraform version v1.1.3

### DIFF
--- a/acceptance-tests/helpers/environment/gcp.go
+++ b/acceptance-tests/helpers/environment/gcp.go
@@ -1,6 +1,10 @@
 package environment
 
-import "os"
+import (
+	"os"
+
+	"github.com/onsi/gomega"
+)
 
 type GCPMetadata struct {
 	Project     string
@@ -8,8 +12,13 @@ type GCPMetadata struct {
 }
 
 func ReadGCPMetadata() GCPMetadata {
-	return GCPMetadata{
+	result := GCPMetadata{
 		Project:     os.Getenv("GOOGLE_PROJECT"),
 		Credentials: os.Getenv("GOOGLE_CREDENTIALS"),
 	}
+
+	gomega.Expect(result.Project).NotTo(gomega.BeEmpty(), "must set GOOGLE_PROJECT")
+	gomega.Expect(result.Credentials).NotTo(gomega.BeEmpty(), "must set GOOGLE_CREDENTIALS")
+
+	return result
 }

--- a/google-bigquery.yml
+++ b/google-bigquery.yml
@@ -88,6 +88,7 @@ provision:
     type: object
   template_refs:
     provider: terraform/bigquery/provision/provider.tf
+    versions: terraform/bigquery/provision/versions.tf
     main: terraform/bigquery/provision/main.tf
     variables: terraform/bigquery/provision/variables.tf
     outputs: terraform/bigquery/provision/outputs.tf

--- a/google-dataproc.yml
+++ b/google-dataproc.yml
@@ -90,6 +90,7 @@ provision:
     type: object
   template_refs:
     provider: terraform/dataproc/provision/provider.tf
+    versions: terraform/dataproc/provision/versions.tf
     main: terraform/dataproc/provision/main.tf
     variables: terraform/dataproc/provision/variables.tf
     outputs: terraform/dataproc/provision/outputs.tf

--- a/google-mysql.yml
+++ b/google-mysql.yml
@@ -144,10 +144,11 @@ provision:
     type: string
   template_refs:
     provider: terraform/cloudsql/provision/provider.tf
-    main:  terraform/cloudsql/provision/main.tf
-    data:  terraform/cloudsql/provision/data.tf
-    variables:  terraform/cloudsql/provision/variables.tf
-    outputs:  terraform/cloudsql/provision/outputs.tf
+    versions: terraform/cloudsql/provision/versions.tf
+    main: terraform/cloudsql/provision/main.tf
+    data: terraform/cloudsql/provision/data.tf
+    variables: terraform/cloudsql/provision/variables.tf
+    outputs: terraform/cloudsql/provision/outputs.tf
   outputs:
   - field_name: name
     type: string
@@ -197,9 +198,10 @@ bind:
     overwrite: true
   template_refs:
     provider: terraform/cloudsql/bindmysql/provider.tf
-    main:  terraform/cloudsql/bindmysql/main.tf
-    variables:  terraform/cloudsql/bindmysql/variables.tf
-    outputs:  terraform/cloudsql/bindmysql/outputs.tf
+    versions: terraform/cloudsql/bindmysql/versions.tf
+    main: terraform/cloudsql/bindmysql/main.tf
+    variables: terraform/cloudsql/bindmysql/variables.tf
+    outputs: terraform/cloudsql/bindmysql/outputs.tf
   outputs:
   - field_name: username
     type: string

--- a/google-postgresql.yml
+++ b/google-postgresql.yml
@@ -55,7 +55,6 @@ provision:
     required: true
     type: number
     details: Minimum number of cores for service instance.
-
   - field_name: postgres_version
     required: true
     type: string
@@ -139,10 +138,11 @@ provision:
     type: string
   template_refs:
     provider: terraform/cloudsql/provision/provider.tf
-    main:  terraform/cloudsql/provision/main.tf
-    data:  terraform/cloudsql/provision/data.tf
-    variables:  terraform/cloudsql/provision/variables.tf
-    outputs:  terraform/cloudsql/provision/outputs.tf
+    versions: terraform/cloudsql/provision/versions.tf
+    main: terraform/cloudsql/provision/main.tf
+    data: terraform/cloudsql/provision/data.tf
+    variables: terraform/cloudsql/provision/variables.tf
+    outputs: terraform/cloudsql/provision/outputs.tf
   outputs:
   - field_name: name
     type: string
@@ -192,9 +192,10 @@ bind:
     overwrite: true
   template_refs:
     provider: terraform/cloudsql/bindpostgresql/provider.tf
-    main:  terraform/cloudsql/bindpostgresql/main.tf
-    variables:  terraform/cloudsql/bindpostgresql/variables.tf
-    outputs:  terraform/cloudsql/bindpostgresql/outputs.tf
+    versions: terraform/cloudsql/bindpostgresql/versions.tf
+    main: terraform/cloudsql/bindpostgresql/main.tf
+    variables: terraform/cloudsql/bindpostgresql/variables.tf
+    outputs: terraform/cloudsql/bindpostgresql/outputs.tf
   outputs:
   - field_name: username
     type: string

--- a/google-redis.yml
+++ b/google-redis.yml
@@ -105,6 +105,7 @@ provision:
     type: object
   template_refs:
     provider: terraform/redis/provision/provider.tf
+    versions: terraform/redis/provision/versions.tf
     main: terraform/redis/provision/main.tf
     data: terraform/redis/provision/data.tf
     variables: terraform/redis/provision/variables.tf

--- a/google-spanner.yml
+++ b/google-spanner.yml
@@ -135,6 +135,7 @@ provision:
     type: object
   template_refs:
     provider: terraform/spanner/provision/provider.tf
+    versions: terraform/spanner/provision/versions.tf
     main: terraform/spanner/provision/main.tf
     data: terraform/spanner/provision/data.tf
     variables: terraform/spanner/provision/variables.tf

--- a/google-stackdriver-trace.yml
+++ b/google-stackdriver-trace.yml
@@ -53,6 +53,7 @@ bind:
     default: 'cloudtrace.agent'
   template_refs:
     provider: terraform/stackdriver/bind/provider.tf
+    versions: terraform/stackdriver/bind/versions.tf
     main: terraform/stackdriver/bind/main.tf
     variables: terraform/stackdriver/bind/variables.tf
     outputs: terraform/stackdriver/bind/outputs.tf

--- a/google-storage.yml
+++ b/google-storage.yml
@@ -103,6 +103,7 @@ provision:
     type: object
   template_refs:
     provider: terraform/storage/provision/provider.tf
+    versions: terraform/storage/provision/versions.tf
     main: terraform/storage/provision/main.tf
     variables: terraform/storage/provision/variables.tf
     outputs: terraform/storage/provision/outputs.tf

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,19 +5,16 @@ metadata:
   author: VMware
 platforms:
 - os: linux
-  arch: amd64 
+  arch: amd64
 # - os: darwin
-#   arch: amd64   
+#   arch: amd64
 terraform_binaries:
 - name: terraform
-  version: 0.12.30
-  source: https://github.com/hashicorp/terraform/archive/v0.12.30.zip  
+  version: 0.13.5
+  source: https://github.com/hashicorp/terraform/archive/v0.13.5.zip
 - name: terraform-provider-google
   version: 4.8.0
   source: https://github.com/terraform-providers/terraform-provider-google/archive/v4.8.0.zip
-- name: terraform-provider-google-beta
-  version: 4.8.0
-  source: https://github.com/terraform-providers/terraform-provider-google-beta/archive/v4.8.0.zip
 - name: terraform-provider-random
   version: 3.1.0
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.1.0.zip

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,8 +10,8 @@ platforms:
 #   arch: amd64
 terraform_binaries:
 - name: terraform
-  version: 0.13.5
-  source: https://github.com/hashicorp/terraform/archive/v0.13.5.zip
+  version: 1.1.4
+  source: https://github.com/hashicorp/terraform/archive/v1.1.4.zip
 - name: terraform-provider-google
   version: 4.8.0
   source: https://github.com/terraform-providers/terraform-provider-google/archive/v4.8.0.zip

--- a/terraform/bigquery/bind/outputs.tf
+++ b/terraform/bigquery/bind/outputs.tf
@@ -1,7 +1,13 @@
 output "Name" { value = google_service_account.account.name }
 output "Email" { value = google_service_account.account.email }
 output "UniqueId" { value = google_service_account.account.unique_id }
-output "PrivateKeyData" { value = google_service_account_key.key.private_key }
+output "PrivateKeyData" {
+  sensitive = true
+  value     = google_service_account_key.key.private_key
+}
 output "ProjectId" { value = google_service_account.account.project }
 output "dataset_id" { value = var.dataset_id }
-output "Credentials" { value = base64decode(google_service_account_key.key.private_key) }
+output "Credentials" {
+  sensitive = true
+  value     = base64decode(google_service_account_key.key.private_key)
+}

--- a/terraform/bigquery/provision/provider.tf
+++ b/terraform/bigquery/provision/provider.tf
@@ -1,11 +1,5 @@
 provider "google" {
-  version     = ">=3.17.0"
   credentials = var.credentials
   project     = var.project
   region      = var.region
-}
-
-provider "google-beta" {
-  version = ">=3.22.0"
-  project = var.project
 }

--- a/terraform/bigquery/provision/versions.tf
+++ b/terraform/bigquery/provision/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=4.8.0"
+    }
+  }
+}

--- a/terraform/cloudsql/bindmysql/outputs.tf
+++ b/terraform/cloudsql/bindmysql/outputs.tf
@@ -1,6 +1,10 @@
 output "username" { value = mysql_user.newuser.user }
-output "password" { value = random_password.password.result }
+output "password" {
+  sensitive = true
+  value     = random_password.password.result
+}
 output "uri" {
+  sensitive = true
   value = format("mysql://%s:%s@%s:%d/%s",
     random_string.username.result,
     random_password.password.result,
@@ -9,6 +13,7 @@ output "uri" {
   var.mysql_db_name)
 }
 output "jdbcUrl" {
+  sensitive = true
   value = format("jdbc:mysql://%s:%d/%s?user=%s\u0026password=%s\u0026useSSL=%v",
     var.mysql_hostname,
     var.mysql_port,

--- a/terraform/cloudsql/bindmysql/versions.tf
+++ b/terraform/cloudsql/bindmysql/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    mysql = {
+      source  = "hashicorp/mysql"
+      version = ">=1.9.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">=3.1.0"
+    }
+  }
+}

--- a/terraform/cloudsql/bindpostgresql/outputs.tf
+++ b/terraform/cloudsql/bindpostgresql/outputs.tf
@@ -1,6 +1,10 @@
 output "username" { value = random_string.username.result }
-output "password" { value = random_password.password.result }
+output "password" {
+  sensitive = true
+  value     = random_password.password.result
+}
 output "uri" {
+  sensitive = true
   value = format("postgresql://%s:%s@%s:%d/%s",
     random_string.username.result,
     random_password.password.result,
@@ -18,6 +22,7 @@ output "uri" {
 } */
 
 output "jdbcUrl" {
+  sensitive = true
   value = format("jdbc:%s://%s:%s/%s?user=%s\u0026password=%s\u0026verifyServerCertificate=true\u0026useSSL=%v\u0026requireSSL=false",
     "postgresql",
     var.hostname,

--- a/terraform/cloudsql/bindpostgresql/versions.tf
+++ b/terraform/cloudsql/bindpostgresql/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    postgresql = {
+      source  = "hashicorp/postgresql"
+      version = ">=1.7.1"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">=3.1.0"
+    }
+  }
+}

--- a/terraform/cloudsql/provision/outputs.tf
+++ b/terraform/cloudsql/provision/outputs.tf
@@ -3,5 +3,8 @@ output "hostname" { value = google_sql_database_instance.instance.first_ip_addre
 
 output "port" { value = (var.database_version == "POSTGRES_11" ? 5432 : 3306) }
 output "username" { value = google_sql_user.admin_user.name }
-output "password" { value = google_sql_user.admin_user.password }
+output "password" {
+  sensitive = true
+  value     = google_sql_user.admin_user.password
+}
 output "use_tls" { value = false }

--- a/terraform/cloudsql/provision/provider.tf
+++ b/terraform/cloudsql/provision/provider.tf
@@ -1,5 +1,4 @@
 provider "google" {
-  version     = ">=3.17.0"
   credentials = var.credentials
   project     = var.project
 }

--- a/terraform/cloudsql/provision/versions.tf
+++ b/terraform/cloudsql/provision/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=4.8.0"
+    }
+  }
+}

--- a/terraform/dataproc/bind/outputs.tf
+++ b/terraform/dataproc/bind/outputs.tf
@@ -1,4 +1,7 @@
 output "email" { value = google_service_account.account.email }
-output "private_key" { value = google_service_account_key.key.private_key }
+output "private_key" {
+  sensitive = true
+  value     = google_service_account_key.key.private_key
+}
 output "project_id" { value = google_service_account.account.project }
 output "name" { value = google_service_account.account.account_id }

--- a/terraform/dataproc/provision/provider.tf
+++ b/terraform/dataproc/provision/provider.tf
@@ -1,5 +1,4 @@
 provider "google" {
-  version     = ">=3.17.0"
   credentials = var.credentials
   project     = var.project
 }

--- a/terraform/dataproc/provision/versions.tf
+++ b/terraform/dataproc/provision/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=4.8.0"
+    }
+  }
+}

--- a/terraform/redis/provision/provider.tf
+++ b/terraform/redis/provision/provider.tf
@@ -1,5 +1,4 @@
 provider "google" {
-  version     = ">=3.17.0"
   credentials = var.credentials
   project     = var.project
 }

--- a/terraform/redis/provision/versions.tf
+++ b/terraform/redis/provision/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=4.8.0"
+    }
+  }
+}

--- a/terraform/spanner/bind/outputs.tf
+++ b/terraform/spanner/bind/outputs.tf
@@ -4,8 +4,14 @@ output "member_etag" { value = join(",", google_spanner_database_iam_member.span
 output "Name" { value = google_service_account.account.name }
 output "Email" { value = google_service_account.account.email }
 output "UniqueId" { value = google_service_account.account.unique_id }
-output "PrivateKeyData" { value = google_service_account_key.key.private_key }
+output "PrivateKeyData" {
+  sensitive = true
+  value     = google_service_account_key.key.private_key
+}
 output "ProjectId" { value = google_service_account.account.project }
 output "instance" { value = var.instance }
 output "db_name" { value = var.db_name }
-output "Credentials" { value = base64decode(google_service_account_key.key.private_key) }
+output "Credentials" {
+  sensitive = true
+  value     = base64decode(google_service_account_key.key.private_key)
+}

--- a/terraform/spanner/provision/provider.tf
+++ b/terraform/spanner/provision/provider.tf
@@ -1,6 +1,4 @@
 provider "google" {
-  version     = ">=3.17.0"
   credentials = var.credentials
   project     = var.project
-
 }

--- a/terraform/spanner/provision/versions.tf
+++ b/terraform/spanner/provision/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=4.8.0"
+    }
+  }
+}

--- a/terraform/stackdriver/bind/outputs.tf
+++ b/terraform/stackdriver/bind/outputs.tf
@@ -1,6 +1,12 @@
 output "Name" { value = google_service_account.account.name }
 output "Email" { value = google_service_account.account.email }
 output "UniqueId" { value = google_service_account.account.unique_id }
-output "PrivateKeyData" { value = google_service_account_key.key.private_key }
+output "PrivateKeyData" {
+  sensitive = true
+  value     = google_service_account_key.key.private_key
+}
 output "ProjectId" { value = google_service_account.account.project }
-output "Credentials" { value = base64decode(google_service_account_key.key.private_key) }
+output "Credentials" {
+  sensitive = true
+  value     = base64decode(google_service_account_key.key.private_key)
+}

--- a/terraform/stackdriver/bind/versions.tf
+++ b/terraform/stackdriver/bind/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=4.8.0"
+    }
+  }
+}

--- a/terraform/storage/bind/outputs.tf
+++ b/terraform/storage/bind/outputs.tf
@@ -1,6 +1,12 @@
 output "Name" { value = google_service_account.account.name }
 output "Email" { value = google_service_account.account.email }
 output "UniqueId" { value = google_service_account.account.unique_id }
-output "PrivateKeyData" { value = google_service_account_key.key.private_key }
+output "PrivateKeyData" {
+  sensitive = true
+  value     = google_service_account_key.key.private_key
+}
 output "ProjectId" { value = google_service_account.account.project }
-output "Credentials" { value = base64decode(google_service_account_key.key.private_key) }
+output "Credentials" {
+  sensitive = true
+  value     = base64decode(google_service_account_key.key.private_key)
+}

--- a/terraform/storage/provision/provider.tf
+++ b/terraform/storage/provision/provider.tf
@@ -1,5 +1,4 @@
 provider "google" {
-  version     = ">=3.17.0"
   credentials = var.credentials
   project     = var.project
 }

--- a/terraform/storage/provision/versions.tf
+++ b/terraform/storage/provision/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">=4.8.0"
+    }
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: because Terraform v1.1 cannot read the terraform
state file from v0.12, if a previous deployment is upgraded to this
version then any previously created services may become unmanageable.
Since this product was at v0.0, breaking changes should be unremarkable,
but we are will to take feedback on this if it causes problems.

[#180858769](https://www.pivotaltracker.com/story/show/180858769)