### PR TITLE
test: random names should be unique

### DIFF
--- a/acceptance-tests/helpers/random/name.go
+++ b/acceptance-tests/helpers/random/name.go
@@ -6,23 +6,41 @@ import (
 	"github.com/Pallinder/go-randomdata"
 )
 
+// We have seen occasions where the same name has been returned more than once, so
+// we should keep a record of previous values to avoid duplicates
+var previous map[string]struct{}
+
 // Name returns a random name that cannot be longer (but may be shorter) than 30
 // characters, or a lower limit if specified.
 func Name(opts ...Option) string {
 	c := cfg(append([]Option{WithMaxLength(100), WithDelimiter("-")}, opts...))
 
-	parts := c.prefix
+	generate := func() string {
+		parts := c.prefix
 
-	// Do we have enough available length to add an adjective?
-	if c.length > len(strings.Join(parts, c.delimiter))+20 {
-		parts = append(parts, randomdata.Adjective())
+		// Do we have enough available length to add an adjective?
+		if c.length > len(strings.Join(parts, c.delimiter))+20 {
+			parts = append(parts, randomdata.Adjective())
+		}
+		parts = append(parts, randomdata.Noun())
+
+		joined := strings.Join(parts, c.delimiter)
+		if len(joined) > c.length {
+			return joined[:c.length]
+		}
+
+		return joined
 	}
-	parts = append(parts, randomdata.Noun())
 
-	joined := strings.Join(parts, c.delimiter)
-	if len(joined) > c.length {
-		return joined[:c.length]
+	if previous == nil {
+		previous = make(map[string]struct{})
 	}
 
-	return joined
+	for {
+		value := generate()
+		if _, ok := previous[value]; !ok {
+			previous[value] = struct{}{}
+			return value
+		}
+	}
 }


### PR DESCRIPTION
We have seen a test fail because the random name generator returned
the same PostgreSQL schema name twice, resulting in a failure to create
the second schema. This change enchances the random name generator so
that previous names are stored and should therefore never be reused.

[#181126745](https://www.pivotaltracker.com/story/show/181126745)
